### PR TITLE
Use the real Main entry point and not the one for local tests.

### DIFF
--- a/TypewriterCli/Program.cs
+++ b/TypewriterCli/Program.cs
@@ -16,7 +16,7 @@ namespace TypewriterCli
     public static class Program
     {
         
-        static void Main(string[] args)
+        static void Main2(string[] args)
         {
             //var dtoInputPath = Path.Combine(@"C:\Development\Firefly.Backbone\Service\Calculator\Risk\Risk.Shared\Dtos");
             var templatePath = Path.Combine(@"C:\Development\Firefly.Backbone\Client\Client", "Api", "_TypeWriterTemplate.tst");
@@ -24,7 +24,7 @@ namespace TypewriterCli
             cliArgs.Recursive = true;
             Generate(cliArgs);
         }
-        public static void Main2(string[] args)
+        public static void Main(string[] args)
         {
             //var stopwatch = Stopwatch.StartNew();
             var showHelp = args == null || args.Length == 0;


### PR DESCRIPTION
Testing the integration with a Rider (Mac OS)  project (asp.net 6) I realize that the main branch was using a "test" Main method. This PR fixes the issue using the correct Main method (uses the input parameters).